### PR TITLE
PHPCS/Composer: update PHPCompatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,10 +25,10 @@
         "php": ">=5.6"
     },
     "require-dev": {
-      "dealerdirect/phpcodesniffer-composer-installer": "^0.4.2",
+      "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
       "phpunit/phpunit": "~4.8|~5.1",
       "squizlabs/php_codesniffer": "^3.0",
-      "wimg/php-compatibility": "^8.0"
+      "phpcompatibility/php-compatibility": "^9.0"
     },
     "autoload": {
       "psr-4": {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -9,7 +9,7 @@
     <arg value="sp"/>
 
     <!-- Check for cross-version support for PHP -->
-    <config name="testVersion" value="5.6"/>
+    <config name="testVersion" value="5.6-"/>
     <rule ref="PHPCompatibility"/>
 
     <!-- PSR2 + some additions -->


### PR DESCRIPTION
Composer:
* `wimg/php-compatibility` has been abandoned for nearly a year. Use `phpcompatibility/php-compatibility` instead.
* Use the latest version of PHPCompatibility.
    You were missing out on a lot of new checks, including the checks to make sure your code is compatible with the upcoming PHP 7.4.
* Use the latest version of the DealerDirect Composer PHPCS plugin.
    Composer treats minors < 1.0 as majors, so you need to explicitely update.

PHPCS ruleset:
* Actually check for cross-version compatibility.
    You were currently just checking if the code was compatible with PHP 5.6, not with _PHP 5.6 and above_.

Refs:
* https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions
* https://github.com/PHPCompatibility/PHPCompatibility/releases/
* https://github.com/Dealerdirect/phpcodesniffer-composer-installer/releases