### PR TITLE
Fix locale issue

### DIFF
--- a/src/Validator.php
+++ b/src/Validator.php
@@ -1055,7 +1055,14 @@ class Validator
      */
     private function stamp($msg)
     {
-        $date = \DateTime::createFromFormat('U.u', sprintf('%.f', microtime(true)))->format('Y-m-d\TH:i:s.uO');
+        $currentLocale = \setlocale(LC_NUMERIC, '0');
+        \setlocale(LC_NUMERIC, 'C');
+
+        $microtime = (string) microtime(true);
+
+        \setlocale(LC_NUMERIC, $currentLocale);
+
+        $date = \DateTime::createFromFormat('U.u', $microtime)->format('Y-m-d\TH:i:s.uO');
         $line = '[' . $date . '] ' . $msg;
 
         return $line;


### PR DESCRIPTION
When the current locale is not set to an English locale, `sprintf()` may not use a dot as decimal separator (nor does float-to-string conversion until PHP 8).

For example, my PHP installation came with `fr_FR.UTF-8` as a locale, and `sprintf('%.f', microtime(true))` returns:

> 1606241584,856880

[Demo on 3v4l](https://3v4l.org/YZiZl)

Which makes `DateTime::createFromFormat()` return `false` and PHP trigger an error on `->format()`:

> PHP Fatal error:  Uncaught Error: Call to a member function format() on bool in (...)/vendor/zytzagoo/smtp-validate-email/src/Validator.php:942

This fixes the issue by temporarily setting the locale to `C`, then reverting to its original value.

I had [the same issue](https://github.com/brick/math/pull/20) on one of my libraries.